### PR TITLE
[WIP] Update client-side cache of prepared statements unconditionally

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -2245,10 +2245,6 @@ public class Cluster implements Closeable {
             if (previous != null) {
                 logger.warn("Re-preparing already prepared query is generally an anti-pattern and will likely affect performance. "
                         + "Consider preparing the statement only once. Query='{}'", stmt.getQueryString());
-
-                // The one object in the cache will get GCed once it's not referenced by the client anymore since we use a weak reference.
-                // So we need to make sure that the instance we do return to the user is the one that is in the cache.
-                return previous;
             }
             return stmt;
         }

--- a/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/Cluster.java
@@ -2241,7 +2241,7 @@ public class Cluster implements Closeable {
         }
 
         public PreparedStatement addPrepared(PreparedStatement stmt) {
-            PreparedStatement previous = preparedQueries.putIfAbsent(stmt.getPreparedId().id, stmt);
+            PreparedStatement previous = preparedQueries.put(stmt.getPreparedId().id, stmt);
             if (previous != null) {
                 logger.warn("Re-preparing already prepared query is generally an anti-pattern and will likely affect performance. "
                         + "Consider preparing the statement only once. Query='{}'", stmt.getQueryString());


### PR DESCRIPTION
https://github.com/YugaByte/yugabyte-db/issues/1425

Because of possible metadata changes not currently governed by query hash, we can't rely on the sole fact of statement being cached by hash meaning it has the latest metadata.

Example:
```cql
CREATE TABLE t (pk int PRIMARY KEY, v int);
# Client prepared a statement SELECT * FROM t WHERE v = ?
DROP TABLE t;
CREATE TABLE t (pk int PRIMARY KEY, v uuid);
# Client prepared another statement from the exact same string
# Binding UUID variable fails with CodecNotFoundException [int <-> java.util.UUID]
```

* This affects Cassandra 3.x as well, and manual explicitly discourage preparing `SELECT *` statements
  * Contrary to what the manual says, this bug also affects the cases when columns are specified explicitly
  * https://docs.datastax.com/en/developer/java-driver/3.2/manual/statements/prepared/#avoid-preparing-select-queries
* In Cassandra 4.x they fixed it, but they took the different approach of including metadata in hash
  * However, Cassandra 4.x driver differs significantly from 3.x, the code changed is this PR isn't even there anymore
  * https://issues.apache.org/jira/browse/CASSANDRA-10786
  * https://github.com/apache/cassandra/commit/922dbdb658b1693973926026b213153d05b4077c
