### PR TITLE
Adjust package order for load balancing class

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -342,9 +342,9 @@ public class DefaultDriverContext implements InternalDriverContext {
         DefaultDriverOption.LOAD_BALANCING_POLICY_CLASS,
         DefaultDriverOption.LOAD_BALANCING_POLICY,
         LoadBalancingPolicy.class,
+        "com.yugabyte.oss.driver.internal.core.loadbalancing",
         "com.datastax.oss.driver.internal.core.loadbalancing",
-        "com.datastax.dse.driver.internal.core.loadbalancing",
-        "com.yugabyte.oss.driver.internal.core.loadbalancing");
+        "com.datastax.dse.driver.internal.core.loadbalancing");
   }
 
   protected Map<String, RetryPolicy> buildRetryPolicies() {


### PR DESCRIPTION
In the test output from TestCassandraSparkWordCount, I saw the following exceptions:
```
java.lang.ClassNotFoundException: com.datastax.oss.driver.internal.core.loadbalancing.PartitionAwarePolicy
    at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
    at java.lang.Class.forName0(Native Method)
    at java.lang.Class.forName(Class.java:264)
    at com.datastax.oss.driver.internal.core.util.Reflection.loadClass(Reflection.java:55)
    at com.datastax.oss.driver.internal.core.util.Reflection.buildFromConfig(Reflection.java:197)
    at com.datastax.oss.driver.internal.core.util.Reflection.buildFromConfigProfiles(Reflection.java:148)
    at com.datastax.oss.driver.internal.core.context.DefaultDriverContext.buildLoadBalancingPolicies(DefaultDriverContext.java:340)
```
```
java.lang.ClassNotFoundException: com.datastax.dse.driver.internal.core.loadbalancing.PartitionAwarePolicy
    at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
    at java.lang.Class.forName0(Native Method)
    at java.lang.Class.forName(Class.java:264)
    at com.datastax.oss.driver.internal.core.util.Reflection.loadClass(Reflection.java:55)
    at com.datastax.oss.driver.internal.core.util.Reflection.buildFromConfig(Reflection.java:197)
    at com.datastax.oss.driver.internal.core.util.Reflection.buildFromConfigProfiles(Reflection.java:148)
    at com.datastax.oss.driver.internal.core.context.DefaultDriverContext.buildLoadBalancingPolicies(DefaultDriverContext.java:340)
```
This is due to the datastax package specified in DefaultDriverContext which is not applicable for yugabyte class.

This PR changes the package to match yugabyte load balancer class.