### PR TITLE
Change order of assertion and log for open connection count

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/ConvictionPolicy.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/ConvictionPolicy.java
@@ -87,8 +87,8 @@ abstract class ConvictionPolicy {
     @Override
     void signalConnectionClosed(Connection connection) {
       int remaining = openConnections.decrementAndGet();
-      assert remaining >= 0;
       Host.statesLogger.debug("[{}] {} closed, remaining = {}", host, connection, remaining);
+      assert remaining >= 0;
     }
 
     @Override
@@ -98,8 +98,8 @@ abstract class ConvictionPolicy {
         if (host.state != Host.State.DOWN) updateReconnectionTime();
 
         remaining = openConnections.decrementAndGet();
-        assert remaining >= 0;
         Host.statesLogger.debug("[{}] {} failed, remaining = {}", host, connection, remaining);
+        assert remaining >= 0;
       } else {
         remaining = openConnections.get();
       }


### PR DESCRIPTION
Over https://detective-gcp.dev.yugabyte.com/job/github-yugabyte-db-phabricator%2F79060%2Fartifact%2Fjava%2Fyb-cql%2Ftarget%2Fsurefire-reports_org.yb.cql.TestAuthenticationCache__testAlterLoginForExistingRole%2Forg.yb.cql.TestAuthenticationCache-output.txt?class=org.yb.cql.TestAuthenticationCache&max_lines=3000&name=testAlterLoginForExistingRole&start_line=3001
```
java.lang.AssertionError
--
3124 | at com.datastax.driver.core.ConvictionPolicy$DefaultConvictionPolicy.signalConnectionClosed(ConvictionPolicy.java:90)
3125 | at com.datastax.driver.core.Connection.closeAsync(Connection.java:886)
3126 | at com.datastax.driver.core.HostConnectionPool.discardAvailableConnections(HostConnectionPool.java:686)
3127 | at com.datastax.driver.core.HostConnectionPool.closeAsync(HostConnectionPool.java:663)
3128 | at com.datastax.driver.core.SessionManager.closeAsync(SessionManager.java:190)
3129 | at com.datastax.driver.core.AbstractSession.close(AbstractSession.java:156)
```
There should be log similar to the following on connection count:
```
2021-03-02 21:50:03,483 (Time-limited test) [INFO - com.datastax.driver.core.ConvictionPolicy$DefaultConvictionPolicy.signalConnectionsOpening(ConvictionPolicy.java:82)] [/127.155.121.13:9042] preparing to open 1 new connections, total = 1
```
However, there was no such log in the test output on Jenkins since the log level is debug.

This changes the log level to INFO so that we can have more information on how the count turned negative.