### PR TITLE
Port JAVA-2331: Unregister old metrics when a node gets removed or changes RPC address

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,10 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+  ### 4.8.0 (in progress)
+  
+ - [bug] JAVA-2331: Unregister old metrics when a node gets removed or changes RPC address
+
 ### 4.6.1
 
 - [bug] JAVA-2676: Don't reschedule write coalescer after empty runs

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/DefaultDriverOption.java
@@ -815,6 +815,14 @@ public enum DefaultDriverOption implements DriverOption {
    * <p>Value-type: int
    */
   SESSION_LEAK_THRESHOLD("advanced.session-leak.threshold"),
+  /**
+   * The period of inactivity after which the node level metrics will be evicted. The eviction will
+   * happen only if none of the enabled node-level metrics is updated for a given node within this
+   * time window.
+   *
+   * <p>Value-type: {@link java.time.Duration Duration}
+   */
+  METRICS_NODE_EXPIRE_AFTER("advanced.metrics.node.expire-after"),
   ;
 
   private final String path;

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/OptionsMap.java
@@ -321,6 +321,7 @@ public class OptionsMap implements Serializable {
     map.put(TypedDriverOption.METRICS_NODE_GRAPH_MESSAGES_HIGHEST, Duration.ofSeconds(3));
     map.put(TypedDriverOption.METRICS_NODE_GRAPH_MESSAGES_DIGITS, 3);
     map.put(TypedDriverOption.METRICS_NODE_GRAPH_MESSAGES_INTERVAL, Duration.ofMinutes(5));
+    map.put(TypedDriverOption.METRICS_NODE_EXPIRE_AFTER, Duration.ofHours(1));
     map.put(TypedDriverOption.SOCKET_TCP_NODELAY, true);
     map.put(TypedDriverOption.HEARTBEAT_INTERVAL, Duration.ofSeconds(30));
     map.put(TypedDriverOption.HEARTBEAT_TIMEOUT, Duration.ofMillis(500));

--- a/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/config/TypedDriverOption.java
@@ -705,6 +705,10 @@ public class TypedDriverOption<ValueT> {
       new TypedDriverOption<>(
           DseDriverOption.METRICS_NODE_GRAPH_MESSAGES_INTERVAL, GenericType.DURATION);
 
+  /** The time after which the node level metrics will be evicted. */
+  public static final TypedDriverOption<Duration> METRICS_NODE_EXPIRE_AFTER =
+      new TypedDriverOption<>(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER, GenericType.DURATION);
+
   private static Iterable<TypedDriverOption<?>> introspectBuiltInValues() {
     try {
       ImmutableList.Builder<TypedDriverOption<?>> result = ImmutableList.builder();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/context/DefaultDriverContext.java
@@ -97,6 +97,7 @@ import com.datastax.oss.driver.internal.core.util.DependencyCheck;
 import com.datastax.oss.driver.internal.core.util.Reflection;
 import com.datastax.oss.driver.internal.core.util.concurrent.CycleDetector;
 import com.datastax.oss.driver.internal.core.util.concurrent.LazyReference;
+import com.datastax.oss.driver.shaded.guava.common.base.Ticker;
 import com.datastax.oss.protocol.internal.Compressor;
 import com.datastax.oss.protocol.internal.FrameCodec;
 import com.datastax.oss.protocol.internal.ProtocolV3ClientCodecs;
@@ -599,7 +600,7 @@ public class DefaultDriverContext implements InternalDriverContext {
   }
 
   protected MetricsFactory buildMetricsFactory() {
-    return new DropwizardMetricsFactory(this);
+    return new DropwizardMetricsFactory(this, Ticker.systemTicker());
   }
 
   protected RequestThrottler buildRequestThrottler() {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardMetricsFactory.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardMetricsFactory.java
@@ -27,7 +27,13 @@ import com.datastax.oss.driver.api.core.metrics.Metrics;
 import com.datastax.oss.driver.api.core.metrics.NodeMetric;
 import com.datastax.oss.driver.api.core.metrics.SessionMetric;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
+import com.datastax.oss.driver.shaded.guava.common.base.Ticker;
+import com.datastax.oss.driver.shaded.guava.common.cache.Cache;
+import com.datastax.oss.driver.shaded.guava.common.cache.CacheBuilder;
+import com.datastax.oss.driver.shaded.guava.common.cache.RemovalNotification;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -41,6 +47,8 @@ import org.slf4j.LoggerFactory;
 public class DropwizardMetricsFactory implements MetricsFactory {
 
   private static final Logger LOG = LoggerFactory.getLogger(DropwizardMetricsFactory.class);
+  static final Duration LOWEST_ACCEPTABLE_EXPIRE_AFTER = Duration.ofMinutes(5);
+  static final Duration DEFAULT_EXPIRE_AFTER = Duration.ofHours(1);
 
   private final String logPrefix;
   private final InternalDriverContext context;
@@ -48,16 +56,34 @@ public class DropwizardMetricsFactory implements MetricsFactory {
   private final MetricRegistry registry;
   @Nullable private final Metrics metrics;
   private final SessionMetricUpdater sessionUpdater;
+  private final Cache<Node, DropwizardNodeMetricUpdater> metricsCache;
 
-  public DropwizardMetricsFactory(InternalDriverContext context) {
+  public DropwizardMetricsFactory(InternalDriverContext context, Ticker ticker) {
     this.logPrefix = context.getSessionName();
     this.context = context;
 
     DriverExecutionProfile config = context.getConfig().getDefaultProfile();
     Set<SessionMetric> enabledSessionMetrics =
         parseSessionMetricPaths(config.getStringList(DefaultDriverOption.METRICS_SESSION_ENABLED));
+    Duration evictionTime = getAndValidateEvictionTime(config, logPrefix);
+
     this.enabledNodeMetrics =
         parseNodeMetricPaths(config.getStringList(DefaultDriverOption.METRICS_NODE_ENABLED));
+
+    metricsCache =
+        CacheBuilder.newBuilder()
+            .ticker(ticker)
+            .expireAfterAccess(evictionTime)
+            .removalListener(
+                (RemovalNotification<Node, DropwizardNodeMetricUpdater> notification) -> {
+                  LOG.debug(
+                      "[{}] Removing metrics for node: {} from cache after {}",
+                      logPrefix,
+                      notification.getKey(),
+                      evictionTime);
+                  notification.getValue().cleanupNodeMetrics();
+                })
+            .build();
 
     if (enabledSessionMetrics.isEmpty() && enabledNodeMetrics.isEmpty()) {
       LOG.debug("[{}] All metrics are disabled, Session.getMetrics will be empty", logPrefix);
@@ -73,6 +99,23 @@ public class DropwizardMetricsFactory implements MetricsFactory {
     }
   }
 
+  @VisibleForTesting
+  static Duration getAndValidateEvictionTime(DriverExecutionProfile config, String logPrefix) {
+    Duration evictionTime = config.getDuration(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER);
+
+    if (evictionTime.compareTo(LOWEST_ACCEPTABLE_EXPIRE_AFTER) < 0) {
+      LOG.warn(
+          "[{}] Value too low for {}: {} (It should be higher than {}). Forcing to {} instead.",
+          logPrefix,
+          DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER.getPath(),
+          evictionTime,
+          LOWEST_ACCEPTABLE_EXPIRE_AFTER,
+          DEFAULT_EXPIRE_AFTER);
+    }
+
+    return evictionTime;
+  }
+
   @Override
   public Optional<Metrics> getMetrics() {
     return Optional.ofNullable(metrics);
@@ -85,9 +128,15 @@ public class DropwizardMetricsFactory implements MetricsFactory {
 
   @Override
   public NodeMetricUpdater newNodeUpdater(Node node) {
-    return (registry == null)
-        ? NoopNodeMetricUpdater.INSTANCE
-        : new DropwizardNodeMetricUpdater(node, enabledNodeMetrics, registry, context);
+    if (registry == null) {
+      return NoopNodeMetricUpdater.INSTANCE;
+    } else {
+      DropwizardNodeMetricUpdater dropwizardNodeMetricUpdater =
+          new DropwizardNodeMetricUpdater(
+              node, enabledNodeMetrics, registry, context, () -> metricsCache.getIfPresent(node));
+      metricsCache.put(node, dropwizardNodeMetricUpdater);
+      return dropwizardNodeMetricUpdater;
+    }
   }
 
   protected Set<SessionMetric> parseSessionMetricPaths(List<String> paths) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardNodeMetricUpdater.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metrics/DropwizardNodeMetricUpdater.java
@@ -16,6 +16,7 @@
 package com.datastax.oss.driver.internal.core.metrics;
 
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.datastax.dse.driver.api.core.config.DseDriverOption;
 import com.datastax.dse.driver.api.core.metrics.DseNodeMetric;
@@ -28,6 +29,7 @@ import com.datastax.oss.driver.api.core.metrics.NodeMetric;
 import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
 import com.datastax.oss.driver.internal.core.pool.ChannelPool;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import net.jcip.annotations.ThreadSafe;
 
@@ -36,13 +38,16 @@ public class DropwizardNodeMetricUpdater extends DropwizardMetricUpdater<NodeMet
     implements NodeMetricUpdater {
 
   private final String metricNamePrefix;
+  private final Runnable signalMetricUpdated;
 
   public DropwizardNodeMetricUpdater(
       Node node,
       Set<NodeMetric> enabledMetrics,
       MetricRegistry registry,
-      InternalDriverContext context) {
+      InternalDriverContext context,
+      Runnable signalMetricUpdated) {
     super(enabledMetrics, registry);
+    this.signalMetricUpdated = signalMetricUpdated;
     this.metricNamePrefix = buildPrefix(context.getSessionName(), node.getEndPoint());
 
     DriverExecutionProfile config = context.getConfig().getDefaultProfile();
@@ -101,6 +106,37 @@ public class DropwizardNodeMetricUpdater extends DropwizardMetricUpdater<NodeMet
     return sessionName + ".nodes." + endPoint.asMetricPrefix() + ".";
   }
 
+  @Override
+  public void incrementCounter(NodeMetric metric, String profileName, long amount) {
+    signalMetricUpdated.run();
+    super.incrementCounter(metric, profileName, amount);
+  }
+
+  @Override
+  public void updateHistogram(NodeMetric metric, String profileName, long value) {
+    signalMetricUpdated.run();
+    super.updateHistogram(metric, profileName, value);
+  }
+
+  @Override
+  public void markMeter(NodeMetric metric, String profileName, long amount) {
+    signalMetricUpdated.run();
+    super.markMeter(metric, profileName, amount);
+  }
+
+  @Override
+  public void updateTimer(NodeMetric metric, String profileName, long duration, TimeUnit unit) {
+    signalMetricUpdated.run();
+    super.updateTimer(metric, profileName, duration, unit);
+  }
+
+  @Override
+  @SuppressWarnings({"unchecked", "TypeParameterUnusedInFormals"})
+  public <T extends Metric> T getMetric(NodeMetric metric, String profileName) {
+    signalMetricUpdated.run();
+    return super.getMetric(metric, profileName);
+  }
+
   private void initializePoolGauge(
       NodeMetric metric,
       Node node,
@@ -115,5 +151,9 @@ public class DropwizardNodeMetricUpdater extends DropwizardMetricUpdater<NodeMet
                 return (pool == null) ? 0 : reading.apply(pool);
               });
     }
+  }
+
+  public void cleanupNodeMetrics() {
+    registry.removeMatching((name, metric) -> name.startsWith(metricNamePrefix));
   }
 }

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -1598,6 +1598,17 @@ datastax-java-driver {
         significant-digits = 3
         refresh-interval = 5 minutes
       }
+
+      # The time after which the node level metrics will be evicted.
+      # The eviction will happen only if none of the enabled node-level
+      # metrics is updated for a given node for a given time.
+      # When this interval elapses, all metrics for the idle node are removed.
+      # If you set it to a value lower than 5 minutes, it will be forced to a default 1 hour.
+      #
+      # Required: no (defaults to 1 hour)
+      # Modifiable at runtime: no
+      # Overridable in a profile: no
+      expire-after = 1 hour
     }
   }
 

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/metrics/DropwizardMetricsFactoryTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/metrics/DropwizardMetricsFactoryTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.metrics;
+
+import static com.datastax.oss.driver.internal.core.metrics.DropwizardMetricsFactory.DEFAULT_EXPIRE_AFTER;
+import static com.datastax.oss.driver.internal.core.metrics.DropwizardMetricsFactory.LOWEST_ACCEPTABLE_EXPIRE_AFTER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ch.qos.logback.classic.Level;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.internal.core.util.LoggerTest;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import com.tngtech.java.junit.dataprovider.UseDataProvider;
+import java.time.Duration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(DataProviderRunner.class)
+public class DropwizardMetricsFactoryTest {
+
+  private static final String LOG_PREFIX = "prefix";
+
+  @Test
+  public void should_log_warning_when_provided_eviction_time_setting_is_too_low() {
+    // given
+    Duration expireAfter = LOWEST_ACCEPTABLE_EXPIRE_AFTER.minusMinutes(1);
+    LoggerTest.LoggerSetup logger =
+        LoggerTest.setupTestLogger(DropwizardMetricsFactory.class, Level.WARN);
+    DriverExecutionProfile driverExecutionProfile = mock(DriverExecutionProfile.class);
+
+    // when
+    when(driverExecutionProfile.getDuration(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER))
+        .thenReturn(expireAfter);
+    DropwizardMetricsFactory.getAndValidateEvictionTime(driverExecutionProfile, LOG_PREFIX);
+
+    // then
+    verify(logger.appender, timeout(500).times(1)).doAppend(logger.loggingEventCaptor.capture());
+    assertThat(logger.loggingEventCaptor.getValue().getMessage()).isNotNull();
+    assertThat(logger.loggingEventCaptor.getValue().getFormattedMessage())
+        .contains(
+            String.format(
+                "[%s] Value too low for %s: %s (It should be higher than %s). Forcing to %s instead.",
+                LOG_PREFIX,
+                DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER.getPath(),
+                expireAfter,
+                LOWEST_ACCEPTABLE_EXPIRE_AFTER,
+                DEFAULT_EXPIRE_AFTER));
+  }
+
+  @Test
+  @UseDataProvider(value = "acceptableEvictionTimes")
+  public void should_not_log_warning_when_provided_eviction_time_setting_is_acceptable(
+      Duration expireAfter) {
+    // given
+    LoggerTest.LoggerSetup logger =
+        LoggerTest.setupTestLogger(DropwizardMetricsFactory.class, Level.WARN);
+    DriverExecutionProfile driverExecutionProfile = mock(DriverExecutionProfile.class);
+
+    // when
+    when(driverExecutionProfile.getDuration(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER))
+        .thenReturn(expireAfter);
+    DropwizardMetricsFactory.getAndValidateEvictionTime(driverExecutionProfile, LOG_PREFIX);
+
+    // then
+    verify(logger.appender, timeout(500).times(0)).doAppend(logger.loggingEventCaptor.capture());
+  }
+
+  @DataProvider
+  public static Object[][] acceptableEvictionTimes() {
+    return new Object[][] {
+      {LOWEST_ACCEPTABLE_EXPIRE_AFTER}, {LOWEST_ACCEPTABLE_EXPIRE_AFTER.plusMinutes(1)}
+    };
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/FakeTicker.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/FakeTicker.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.core.metrics;
+
+import com.datastax.oss.driver.shaded.guava.common.base.Ticker;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** A Ticker whose value can be advanced programmatically in test. */
+public class FakeTicker extends Ticker {
+
+  private final AtomicLong nanos = new AtomicLong();
+
+  public FakeTicker advance(long nanoseconds) {
+    nanos.addAndGet(nanoseconds);
+    return this;
+  }
+
+  public FakeTicker advance(Duration duration) {
+    return advance(duration.toNanos());
+  }
+
+  @Override
+  public long read() {
+    return nanos.get();
+  }
+}

--- a/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/MetricsSimulacronIT.java
+++ b/integration-tests/src/test/java/com/datastax/oss/driver/core/metrics/MetricsSimulacronIT.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.core.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import com.codahale.metrics.Meter;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metrics.DefaultNodeMetric;
+import com.datastax.oss.driver.api.core.metrics.DefaultSessionMetric;
+import com.datastax.oss.driver.api.core.metrics.Metrics;
+import com.datastax.oss.driver.api.core.session.ProgrammaticArguments;
+import com.datastax.oss.driver.api.core.session.SessionBuilder;
+import com.datastax.oss.driver.api.testinfra.session.SessionUtils;
+import com.datastax.oss.driver.api.testinfra.simulacron.SimulacronRule;
+import com.datastax.oss.driver.categories.ParallelizableTests;
+import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
+import com.datastax.oss.driver.internal.core.context.InternalDriverContext;
+import com.datastax.oss.driver.internal.core.metrics.DropwizardMetricsFactory;
+import com.datastax.oss.driver.internal.core.metrics.MetricsFactory;
+import com.datastax.oss.driver.shaded.guava.common.base.Ticker;
+import com.datastax.oss.simulacron.common.cluster.ClusterSpec;
+import com.google.common.collect.Lists;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(ParallelizableTests.class)
+public class MetricsSimulacronIT {
+
+  @ClassRule
+  public static final SimulacronRule SIMULACRON_RULE =
+      new SimulacronRule(ClusterSpec.builder().withNodes(1));
+
+  @Before
+  public void clearPrimes() {
+    SIMULACRON_RULE.cluster().clearLogs();
+    SIMULACRON_RULE.cluster().clearPrimes(true);
+  }
+
+  @Test
+  public void should_remove_node_metrics_and_not_remove_session_metrics_after_eviction_time() {
+
+    // given
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withStringList(
+                DefaultDriverOption.METRICS_SESSION_ENABLED,
+                Lists.newArrayList("bytes-sent", "bytes-received"))
+            .withStringList(
+                DefaultDriverOption.METRICS_NODE_ENABLED,
+                Lists.newArrayList("bytes-sent", "bytes-received"))
+            .withDuration(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER, Duration.ofHours(1))
+            .build();
+    FakeTicker fakeTicker = new FakeTicker();
+    try (CqlSession session =
+        new MetricsTestContextBuilder()
+            .addContactEndPoints(SIMULACRON_RULE.getContactPoints())
+            .withConfigLoader(loader)
+            .withTicker(fakeTicker)
+            .build()) {
+      for (int i = 0; i < 10; i++) {
+        session.execute("SELECT release_version FROM system.local");
+      }
+
+      // when
+      fakeTicker.advance(Duration.ofHours(2));
+
+      // then session metrics are not evicted
+      assertThat(session.getMetrics())
+          .hasValueSatisfying(
+              metrics -> {
+                assertThat(metrics.<Meter>getSessionMetric(DefaultSessionMetric.BYTES_SENT))
+                    .hasValueSatisfying(
+                        bytesSent -> assertThat(bytesSent.getCount()).isGreaterThan(0));
+                assertThat(metrics.<Meter>getSessionMetric(DefaultSessionMetric.BYTES_RECEIVED))
+                    .hasValueSatisfying(
+                        bytesReceived -> assertThat(bytesReceived.getCount()).isGreaterThan(0));
+              });
+
+      // and node metrics are evicted
+      await()
+          .until(
+              () -> {
+                // get only node in a cluster and evaluate its metrics.
+                Node node = session.getMetadata().getNodes().values().iterator().next();
+                Metrics metrics = session.getMetrics().get();
+                return !metrics.<Meter>getNodeMetric(node, DefaultNodeMetric.BYTES_SENT).isPresent()
+                    && !metrics
+                        .<Meter>getNodeMetric(node, DefaultNodeMetric.BYTES_RECEIVED)
+                        .isPresent();
+              });
+    }
+  }
+
+  @Test
+  public void
+      should_not_evict_not_updated_node_metric_if_any_other_node_level_metric_was_updated() {
+    // given
+    DriverConfigLoader loader =
+        SessionUtils.configLoaderBuilder()
+            .withStringList(
+                DefaultDriverOption.METRICS_NODE_ENABLED,
+                Lists.newArrayList("bytes-sent", "errors.request.aborted"))
+            .withDuration(DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER, Duration.ofHours(1))
+            .build();
+    FakeTicker fakeTicker = new FakeTicker();
+    try (CqlSession session =
+        new MetricsTestContextBuilder()
+            .addContactEndPoints(SIMULACRON_RULE.getContactPoints())
+            .withConfigLoader(loader)
+            .withTicker(fakeTicker)
+            .build()) {
+      for (int i = 0; i < 10; i++) {
+        session.execute("SELECT release_version FROM system.local");
+      }
+
+      // when advance time to before eviction
+      fakeTicker.advance(Duration.ofMinutes(59));
+      // execute query that update only bytes-sent
+      session.execute("SELECT release_version FROM system.local");
+      // advance time to after eviction
+      fakeTicker.advance(Duration.ofMinutes(2));
+
+      // then all node-level metrics should not be evicted
+      await()
+          .until(
+              () -> {
+                // get only node in a cluster and evaluate its metrics.
+                Node node = session.getMetadata().getNodes().values().iterator().next();
+                Metrics metrics = session.getMetrics().get();
+                return metrics.<Meter>getNodeMetric(node, DefaultNodeMetric.BYTES_SENT).isPresent()
+                    && metrics
+                        .<Meter>getNodeMetric(node, DefaultNodeMetric.ABORTED_REQUESTS)
+                        .isPresent();
+              });
+    }
+  }
+
+  private static class MetricsTestContextBuilder
+      extends SessionBuilder<MetricsTestContextBuilder, CqlSession> {
+
+    private Ticker ticker;
+
+    @Override
+    protected CqlSession wrap(@NonNull CqlSession defaultSession) {
+      return defaultSession;
+    }
+
+    public MetricsTestContextBuilder withTicker(Ticker ticker) {
+      this.ticker = ticker;
+      return this;
+    }
+
+    @Override
+    protected DriverContext buildContext(
+        DriverConfigLoader configLoader, ProgrammaticArguments programmaticArguments) {
+      return new MetricsTestContext(configLoader, programmaticArguments, ticker);
+    }
+  }
+
+  private static class MetricsTestContext extends DefaultDriverContext {
+    private final Ticker ticker;
+
+    public MetricsTestContext(
+        @NonNull DriverConfigLoader configLoader,
+        @NonNull ProgrammaticArguments programmaticArguments,
+        @NonNull Ticker ticker) {
+      super(configLoader, programmaticArguments);
+      this.ticker = ticker;
+    }
+
+    @Override
+    protected MetricsFactory buildMetricsFactory() {
+      return new DropwizardMetricsFactoryCustomTicker(this, ticker);
+    }
+
+    private static class DropwizardMetricsFactoryCustomTicker extends DropwizardMetricsFactory {
+
+      public DropwizardMetricsFactoryCustomTicker(InternalDriverContext context, Ticker ticker) {
+        super(context, ticker);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This backport is needed for Janusgraph which references DefaultDriverOption.METRICS_NODE_EXPIRE_AFTER