### PR TITLE
Pass empty Configuration in DelegatingCluster

### DIFF
--- a/driver-core/src/main/java/com/datastax/driver/core/DelegatingCluster.java
+++ b/driver-core/src/main/java/com/datastax/driver/core/DelegatingCluster.java
@@ -46,7 +46,7 @@ public abstract class DelegatingCluster extends Cluster {
 
     // Construct parent class with dummy parameters that will never get used (since super.init() is
     // never called).
-    super("delegating_cluster", Collections.<EndPoint>emptyList(), null);
+    super("delegating_cluster", Collections.<EndPoint>emptyList(), Configuration.builder().build());
 
     // Immediately close the parent class's internal Manager, to make sure that it will fail fast if
     // it's ever


### PR DESCRIPTION
Otherwise, it causes NPE at https://github.com/yugabyte/cassandra-java-driver/blob/3.8.0-yb-x/driver-core/src/main/java/com/datastax/driver/core/Cluster.java#L1620