### PR TITLE
[cassandra driver] Check ColumnDefinitions size before de-referencing its element

### DIFF
--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
@@ -104,15 +104,15 @@ public class PartitionAwarePolicy extends DefaultLoadBalancingPolicy implements 
     PreparedStatement pstmt = statement.getPreparedStatement();
     String query = pstmt.getQuery();
     ColumnDefinitions variables = pstmt.getVariableDefinitions();
-    String queryKeySpace = variables.get(0).getKeyspace().asInternal();
-    String queryTable = variables.get(0).getTable().asInternal();
-
     // Look up the hosts for the partition key. Skip statements that do not have
     // bind variables.
     if (variables.size() == 0) return null;
-    LOG.debug("getQueryPlan: keyspace = " + queryKeySpace + ", query = " + query);
     int key = getKey(statement);
     if (key < 0) return null;
+    String queryKeySpace = variables.get(0).getKeyspace().asInternal();
+    String queryTable = variables.get(0).getTable().asInternal();
+
+    LOG.debug("getQueryPlan: keyspace = " + queryKeySpace + ", query = " + query);
 
     Optional<DefaultPartitionMetadata> partitionMetadata =
         session.getMetadata().getDefaultPartitionMetadata();


### PR DESCRIPTION
Aravind reported the following exception when running sample app with 4.6 driver:
```
Exception in thread "main" java.lang.ArrayIndexOutOfBoundsException
    at com.datastax.oss.driver.internal.core.cql.EmptyColumnDefinitions.get(EmptyColumnDefinitions.java:41)
    at com.yugabyte.oss.driver.internal.core.loadbalancing.PartitionAwarePolicy.getQueryPlan(PartitionAwarePolicy.java:107)
    at com.yugabyte.oss.driver.internal.core.loadbalancing.PartitionAwarePolicy.newQueryPlan(PartitionAwarePolicy.java:75)
```
This happened because the check of the size of ColumnDefinitions should be performed before de-referencing its element.

The PR has been tested by modifying java/yb-cql-4x/src/test/java/org/yb/loadtest/TestSpark3Locality.java with extra ALTER TABLE statement (which passes based on the PR).