### PR TITLE
[cassandra driver] Assign consistency level of BatchStatement to first BoundStatement

### DIFF
--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
@@ -142,6 +142,9 @@ public class PartitionAwarePolicy extends DefaultLoadBalancingPolicy implements 
     while (batchIterator.hasNext()) {
       BatchableStatement<?> nextStatement = batchIterator.next();
       if (nextStatement instanceof BoundStatement) {
+        if (batch.getConsistencyLevel() != null && nextStatement.getConsistencyLevel() == null) {
+          nextStatement = nextStatement.setConsistencyLevel(batch.getConsistencyLevel());
+        }
         Iterator<Node> plan = getQueryPlan(session, (BoundStatement) nextStatement);
         if (plan != null) return plan;
       }


### PR DESCRIPTION
In getQueryPlan(Session session, BatchStatement batch), the first BoundStatement is used to construct UpHostIterator.

If the consistency level of BatchStatement is set but that of the first BoundStatement is not set, we should assign consistency level of BatchStatement to first BoundStatement.

Thanks to Aravind for the observation.

Without this fix, ConsistencyLevel.YB_CONSISTENT_PREFIX would be used for the first BoundStatement (whose ConsistencyLevel is not set).
```
    private ConsistencyLevel getConsistencyLevel() {
      return statement.getConsistencyLevel() != null
          ? statement.getConsistencyLevel()
          : ConsistencyLevel.YB_CONSISTENT_PREFIX;
```
which would result in shuffling of the hosts, leaving leader not in the front:
```
      if (getConsistencyLevel() == ConsistencyLevel.YB_CONSISTENT_PREFIX) {
        Collections.shuffle(hosts);
```