### PR TITLE
Code fix for #10117 - Incorrect traffic routing in multi-dc/multi-region clusters

### DIFF
--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
@@ -57,7 +57,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class PartitionAwarePolicy extends DefaultLoadBalancingPolicy implements RequestTracker {
+public class PartitionAwarePolicy extends YugabyteDefaultLoadBalancingPolicy implements RequestTracker {
 
   private static final Logger LOG = LoggerFactory.getLogger(PartitionAwarePolicy.class);
 

--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
@@ -12,21 +12,6 @@
 //
 package com.yugabyte.oss.driver.internal.core.loadbalancing;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.Channels;
-import java.nio.channels.WritableByteChannel;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.UUID;
-
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.context.DriverContext;
 import com.datastax.oss.driver.api.core.cql.BatchStatement;
@@ -44,20 +29,34 @@ import com.datastax.oss.driver.api.core.type.DataType;
 import com.datastax.oss.driver.api.core.type.MapType;
 import com.datastax.oss.driver.api.core.type.SetType;
 import com.datastax.oss.driver.api.core.type.UserDefinedType;
-import com.datastax.oss.driver.internal.core.loadbalancing.DefaultLoadBalancingPolicy;
 import com.datastax.oss.driver.internal.core.util.collection.QueryPlan;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import com.yugabyte.oss.driver.api.core.DefaultPartitionMetadata;
 import com.yugabyte.oss.driver.api.core.TableSplitMetadata;
 import com.yugabyte.oss.driver.api.core.utils.Jenkins;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.UUID;
 import net.jcip.annotations.ThreadSafe;
 import org.apache.commons.collections.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @ThreadSafe
-public class PartitionAwarePolicy extends YugabyteDefaultLoadBalancingPolicy implements RequestTracker {
+public class PartitionAwarePolicy extends YugabyteDefaultLoadBalancingPolicy
+    implements RequestTracker {
 
   private static final Logger LOG = LoggerFactory.getLogger(PartitionAwarePolicy.class);
 
@@ -89,9 +88,11 @@ public class PartitionAwarePolicy extends YugabyteDefaultLoadBalancingPolicy imp
       LOG.debug("newQueryPlan: Number of Nodes = " + partitionAwareNodes.size());
     }
 
-    // It so happens that the partition aware nodes could be non-empty, but the state of the nodes could be down.
+    // It so happens that the partition aware nodes could be non-empty, but the state of the nodes
+    // could be down.
     // In such cases fallback to the inherited load-balancing logic
-    return !CollectionUtils.isEmpty(partitionAwareNodes) ? new QueryPlan(partitionAwareNodes.toArray())
+    return !CollectionUtils.isEmpty(partitionAwareNodes)
+        ? new QueryPlan(partitionAwareNodes.toArray())
         : super.newQueryPlan(request, session);
   }
 
@@ -189,7 +190,7 @@ public class PartitionAwarePolicy extends YugabyteDefaultLoadBalancingPolicy imp
     private ConsistencyLevel getConsistencyLevel() {
       return statement.getConsistencyLevel() != null
           ? statement.getConsistencyLevel()
-          : ConsistencyLevel.YB_CONSISTENT_PREFIX;
+          : ConsistencyLevel.YB_STRONG;
     }
 
     @Override

--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/YugabyteDefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/YugabyteDefaultLoadBalancingPolicy.java
@@ -1,0 +1,194 @@
+package com.yugabyte.oss.driver.internal.core.loadbalancing;
+
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import com.datastax.oss.driver.api.core.loadbalancing.NodeDistance;
+import com.datastax.oss.driver.api.core.metadata.Node;
+import com.datastax.oss.driver.api.core.metadata.NodeState;
+import com.datastax.oss.driver.api.core.session.Request;
+import com.datastax.oss.driver.api.core.session.Session;
+import com.datastax.oss.driver.api.core.tracker.RequestTracker;
+import com.datastax.oss.driver.internal.core.loadbalancing.BasicLoadBalancingPolicy;
+import com.datastax.oss.driver.internal.core.util.ArrayUtils;
+import com.datastax.oss.driver.internal.core.util.collection.QueryPlan;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Map;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.function.Predicate;
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy implements RequestTracker {
+
+  private static final Logger LOG = LoggerFactory.getLogger(YugabyteDefaultLoadBalancingPolicy.class);
+
+  private volatile DistanceReporter distanceReporter;
+  private volatile Predicate<Node> filter;
+  private volatile String localDc;
+
+  protected final CopyOnWriteArraySet<Node> localDCliveNodes = new CopyOnWriteArraySet<>();
+  protected final Map<Node, AtomicLongArray> responseTimes = new ConcurrentHashMap<>();
+
+  public YugabyteDefaultLoadBalancingPolicy(DriverContext context, String profileName) {
+    super(context, profileName);
+  }
+
+  @Override
+  public void init(@NonNull Map<UUID, Node> nodes, @NonNull DistanceReporter distanceReporter) {
+    this.distanceReporter = distanceReporter;
+    localDc = discoverLocalDc(nodes).orElse(null);
+    filter = createNodeFilter(localDc, nodes);
+
+    for (Node node : nodes.values()) {
+      isLiveNode(node);
+    }
+  }
+
+  @NonNull
+  @Override
+  public Queue<Node> newQueryPlan(@Nullable Request request, @Nullable Session session) {
+    // Take a snapshot since the set is concurrent:
+    Object[] currentNodes = null;
+
+    if (!StringUtils.isBlank(localDc)) {
+
+      currentNodes = localDCliveNodes.toArray();
+      // if there are no healthy nodes in the localDC, then consider nodes from other
+      // DCs.
+      if (currentNodes.length == 0) {
+
+        LOG.trace("[{}] No nodes available in Local DC {}, falling back on to liveNodes", logPrefix, localDc);
+        currentNodes = liveNodes.toArray();
+      }
+
+    } else {
+      currentNodes = liveNodes.toArray();
+    }
+
+    LOG.trace("[{}] Round-robing the {} avaiable nodes", logPrefix, currentNodes.length);
+
+    // Round-robin the remaining nodes
+    ArrayUtils.rotate(currentNodes, 0, currentNodes.length, roundRobinAmount.getAndUpdate(INCREMENT));
+
+    return new QueryPlan(currentNodes);
+  }
+
+  @Override
+  public void onUp(@NonNull Node node) {
+    isLiveNode(node);
+  }
+
+  @Override
+  public void onAdd(@NonNull Node node) {
+    isLiveNode(node);
+  }
+
+  @Override
+  public void onNodeSuccess(@NonNull Request request, long latencyNanos,
+      @NonNull DriverExecutionProfile executionProfile, @NonNull Node node, @NonNull String logPrefix) {
+    updateResponseTimes(node);
+  }
+
+  @Override
+  public void onNodeError(@NonNull Request request, @NonNull Throwable error, long latencyNanos,
+      @NonNull DriverExecutionProfile executionProfile, @NonNull Node node, @NonNull String logPrefix) {
+    updateResponseTimes(node);
+  }
+
+  private void isLiveNode(@NonNull Node node) {
+
+    // For YCQL, when localDC is provided, use the DefaultNodeFilterHelper to find
+    // out the
+    // local nodes.
+    if (!StringUtils.isBlank(localDc)) {
+
+      if (filter.test(node)) {
+        distanceReporter.setDistance(node, NodeDistance.LOCAL);
+        if (node.getState() != NodeState.DOWN) {
+          // This includes state == UNKNOWN. If the node turns out to be unreachable, this
+          // will be
+          // detected when we try to open a pool to it, it will get marked down and this
+          // will be
+          // signaled back to this policy
+          localDCliveNodes.add(node);
+        }
+      } else {
+
+        // For Multi-DC/Multi-region YugabyteDB Clusters, leader tablets can be present
+        // in the DC's
+        // other than the DC considered as LOCAL. Hence we'll need to consider the nodes
+        // from
+        // other DC's as live for routing the YCQL operations.
+        if (node.getState() == NodeState.UP || node.getState() == NodeState.UNKNOWN) {
+          liveNodes.add(node);
+          LOG.debug("[{}] Adding {} as it belongs to the {} DC in Multi-DC/Region Setup", logPrefix, node,
+              node.getDatacenter());
+          distanceReporter.setDistance(node, NodeDistance.REMOTE);
+        } else {
+          distanceReporter.setDistance(node, NodeDistance.IGNORED);
+        }
+      }
+    } else {
+      // For YCQL, When Local DC is not provided, all the available UP nodes will be
+      // considered
+      // local
+      distanceReporter.setDistance(node, NodeDistance.LOCAL);
+      if (node.getState() != NodeState.DOWN) {
+        // This includes state == UNKNOWN. If the node turns out to be unreachable, this
+        // will be
+        // detected when we try to open a pool to it, it will get marked down and this
+        // will be
+        // signaled back to this policy
+        liveNodes.add(node);
+      }
+    }
+  }
+
+  protected void updateResponseTimes(@NonNull Node node) {
+    responseTimes.compute(node, (n, array) -> {
+      // The array stores at most two timestamps, since we don't need more;
+      // the first one is always the least recent one, and hence the one to inspect.
+      long now = nanoTime();
+      if (array == null) {
+        array = new AtomicLongArray(1);
+        array.set(0, now);
+      } else if (array.length() == 1) {
+        long previous = array.get(0);
+        array = new AtomicLongArray(2);
+        array.set(0, previous);
+        array.set(1, now);
+      } else {
+        array.set(0, array.get(1));
+        array.set(1, now);
+      }
+      return array;
+    });
+  }
+
+  protected long nanoTime() {
+    return System.nanoTime();
+  }
+
+  // private void addToLiveNodes(@NonNull Node node) {
+  //
+  // String dc = node.getDatacenter();
+  // if (dc == null) {
+  // LOG.trace("[{}] Datacenter value not avaiable for node {}", logPrefix,
+  // node.getEndPoint());
+  // }
+  //
+  // CopyOnWriteArrayList<Node> prev = perDcLiveNodes.get(dc);
+  // if (prev == null)
+  // perDcLiveNodes.put(dc, new
+  // CopyOnWriteArrayList<Node>(Collections.singletonList(node)));
+  // else
+  // prev.addIfAbsent(node);
+  // }
+
+}

--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/YugabyteDefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/YugabyteDefaultLoadBalancingPolicy.java
@@ -75,7 +75,7 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
     Object[] currentNodes = null;
 
     ConsistencyLevel requestConsistencyLevel = findConsistencyLevelForRequest(request);
-    
+
     // LocalDC: Requests will routed to local DC only for CL.ONE or CL.YB_CONSISTENT_PREFIX
     if (!StringUtils.isBlank(localDc)
         && requestConsistencyLevel == ConsistencyLevel.YB_CONSISTENT_PREFIX) {
@@ -202,26 +202,26 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
       }
     }
   }
-  
+
   private boolean handleNodeDownEvent(Node node) {
-	  boolean handleSuccess = false;
-	  
-	  if (liveNodesInAllDC.contains(node)) {
-		  liveNodesInAllDC.remove(node);
-		  handleSuccess = true;
-	  }
-	  
-	  if (liveNodesInLocalDc.contains(node)) {
-		  liveNodesInLocalDc.remove(node);
-		  handleSuccess = true;
-	  }
-	  
-	  if (liveNodes.contains(node)) {
-		  liveNodes.remove(node);
-		  handleSuccess = true;
-	  }
-	  
-	  return handleSuccess;
+    boolean handleSuccess = false;
+
+    if (liveNodesInAllDC.contains(node)) {
+      liveNodesInAllDC.remove(node);
+      handleSuccess = true;
+    }
+
+    if (liveNodesInLocalDc.contains(node)) {
+      liveNodesInLocalDc.remove(node);
+      handleSuccess = true;
+    }
+
+    if (liveNodes.contains(node)) {
+      liveNodes.remove(node);
+      handleSuccess = true;
+    }
+
+    return handleSuccess;
   }
 
   private ConsistencyLevel findConsistencyLevelForRequest(Request request) {

--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/YugabyteDefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/YugabyteDefaultLoadBalancingPolicy.java
@@ -24,9 +24,11 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy implements RequestTracker {
+public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
+    implements RequestTracker {
 
-  private static final Logger LOG = LoggerFactory.getLogger(YugabyteDefaultLoadBalancingPolicy.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(YugabyteDefaultLoadBalancingPolicy.class);
 
   private volatile DistanceReporter distanceReporter;
   private volatile Predicate<Node> filter;
@@ -63,7 +65,10 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
       // DCs.
       if (currentNodes.length == 0) {
 
-        LOG.trace("[{}] No nodes available in Local DC {}, falling back on to liveNodes", logPrefix, localDc);
+        LOG.trace(
+            "[{}] No nodes available in Local DC {}, falling back on to liveNodes",
+            logPrefix,
+            localDc);
         currentNodes = liveNodes.toArray();
       }
 
@@ -74,7 +79,8 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
     LOG.trace("[{}] Round-robing the {} avaiable nodes", logPrefix, currentNodes.length);
 
     // Round-robin the remaining nodes
-    ArrayUtils.rotate(currentNodes, 0, currentNodes.length, roundRobinAmount.getAndUpdate(INCREMENT));
+    ArrayUtils.rotate(
+        currentNodes, 0, currentNodes.length, roundRobinAmount.getAndUpdate(INCREMENT));
 
     return new QueryPlan(currentNodes);
   }
@@ -90,14 +96,23 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
   }
 
   @Override
-  public void onNodeSuccess(@NonNull Request request, long latencyNanos,
-      @NonNull DriverExecutionProfile executionProfile, @NonNull Node node, @NonNull String logPrefix) {
+  public void onNodeSuccess(
+      @NonNull Request request,
+      long latencyNanos,
+      @NonNull DriverExecutionProfile executionProfile,
+      @NonNull Node node,
+      @NonNull String logPrefix) {
     updateResponseTimes(node);
   }
 
   @Override
-  public void onNodeError(@NonNull Request request, @NonNull Throwable error, long latencyNanos,
-      @NonNull DriverExecutionProfile executionProfile, @NonNull Node node, @NonNull String logPrefix) {
+  public void onNodeError(
+      @NonNull Request request,
+      @NonNull Throwable error,
+      long latencyNanos,
+      @NonNull DriverExecutionProfile executionProfile,
+      @NonNull Node node,
+      @NonNull String logPrefix) {
     updateResponseTimes(node);
   }
 
@@ -127,7 +142,10 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
         // other DC's as live for routing the YCQL operations.
         if (node.getState() == NodeState.UP || node.getState() == NodeState.UNKNOWN) {
           liveNodes.add(node);
-          LOG.debug("[{}] Adding {} as it belongs to the {} DC in Multi-DC/Region Setup", logPrefix, node,
+          LOG.debug(
+              "[{}] Adding {} as it belongs to the {} DC in Multi-DC/Region Setup",
+              logPrefix,
+              node,
               node.getDatacenter());
           distanceReporter.setDistance(node, NodeDistance.REMOTE);
         } else {
@@ -151,24 +169,26 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
   }
 
   protected void updateResponseTimes(@NonNull Node node) {
-    responseTimes.compute(node, (n, array) -> {
-      // The array stores at most two timestamps, since we don't need more;
-      // the first one is always the least recent one, and hence the one to inspect.
-      long now = nanoTime();
-      if (array == null) {
-        array = new AtomicLongArray(1);
-        array.set(0, now);
-      } else if (array.length() == 1) {
-        long previous = array.get(0);
-        array = new AtomicLongArray(2);
-        array.set(0, previous);
-        array.set(1, now);
-      } else {
-        array.set(0, array.get(1));
-        array.set(1, now);
-      }
-      return array;
-    });
+    responseTimes.compute(
+        node,
+        (n, array) -> {
+          // The array stores at most two timestamps, since we don't need more;
+          // the first one is always the least recent one, and hence the one to inspect.
+          long now = nanoTime();
+          if (array == null) {
+            array = new AtomicLongArray(1);
+            array.set(0, now);
+          } else if (array.length() == 1) {
+            long previous = array.get(0);
+            array = new AtomicLongArray(2);
+            array.set(0, previous);
+            array.set(1, now);
+          } else {
+            array.set(0, array.get(1));
+            array.set(1, now);
+          }
+          return array;
+        });
   }
 
   protected long nanoTime() {

--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/YugabyteDefaultLoadBalancingPolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/YugabyteDefaultLoadBalancingPolicy.java
@@ -64,7 +64,7 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
     filter = createNodeFilter(localDc, nodes);
 
     for (Node node : nodes.values()) {
-      isLiveNode(node);
+      addToLiveNodeLists(node);
     }
   }
 
@@ -107,12 +107,12 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
 
   @Override
   public void onUp(@NonNull Node node) {
-    isLiveNode(node);
+    addToLiveNodeLists(node);
   }
 
   @Override
   public void onAdd(@NonNull Node node) {
-    isLiveNode(node);
+    addToLiveNodeLists(node);
   }
 
   @Override
@@ -150,7 +150,7 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
     updateResponseTimes(node);
   }
 
-  private void isLiveNode(@NonNull Node node) {
+  private void addToLiveNodeLists(@NonNull Node node) {
 
     // For YCQL, when localDC is provided, use the DefaultNodeFilterHelper to find
     // out the local nodes and also maintain list of all the live nodes in every DC.
@@ -233,10 +233,9 @@ public class YugabyteDefaultLoadBalancingPolicy extends BasicLoadBalancingPolicy
 
       Statement<?> ycqlStatement = (Statement<?>) request;
 
-      statementConsistencyLevel =
-          ycqlStatement.getConsistencyLevel() != null
-              ? ycqlStatement.getConsistencyLevel()
-              : ConsistencyLevel.YB_STRONG;
+      if (ycqlStatement.getConsistencyLevel() != null) {
+        statementConsistencyLevel = ycqlStatement.getConsistencyLevel();
+      }
     }
 
     return statementConsistencyLevel;


### PR DESCRIPTION
### Partition-Aware Load Balancing Related Issues:
1. Traffic Always being routed to local DC nodes in Multi-DC/Multi-region setup
2. Specifying Local DC should not be mandatory
3. Default Consistency policy should be set to `QUORUM/YB_STRONG`

### Analysis

1. `BasicLoadBalancingPolicy` was responsible for management of `LiveNodes` and `NodeDistance` for each node in the cluster. During initialisation, nodes were iterated through and only the nodes from the localDC were considered as part of the LiveNodes and Rest of nodes were marked as `IGNORED` which resulted in driver ignoring all the `UP` nodes in other DCs/Regions. Hence all the traffic were routed to the nodes from the `local` DC. For YCQL, we need to overhaul how the `livenodes` management is being handled in the `BasicLoadBalancingPolicy`. 
 
2. `ParitionAwarePolicy` was being extended `DefaultLoadBalancingPolicy` by default it required CqlSession to specify the DC name. This behaviour needs to be changed for YCQL as it is possible tablet leaders are spread out across all the available regions. 

3. When consistency policy is not set at the statement level, `PartitionAwarePolicy` was incorrectly using `YB_CONSISTENT_PREFIX` instead of `YB_STRONG`.

### Code Fix

1. Created a new base class `YugabyteDefaultLoadBalancingPolicy` which handles the management of `livenodes` according to YugabyteDB cluster topology. Nodes from other DCs will not be marked as `IGNORED`, if the node is healthy and has the leader tablet, request will directly go to that specific node.

2. Update the `PartitionAwarePolicy.discoverLocalDc()` to use `OptionalLocalDcHelper` instead of `MandatoryLocalDcHelper`.

3. Default `ConsistencyLevel` in `PartitionAwarePolicy` is changed to `YB_STRONG`.