### PR TITLE
Update Jackson Binding version for Driver version 3.10.x

### DIFF
--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-core</artifactId>
@@ -384,7 +384,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-SNAPSHOT</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-core</artifactId>
@@ -384,7 +384,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2</tag>
     </scm>
 
     <developers>

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <artifactId>cassandra-driver-core</artifactId>
@@ -384,7 +384,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2-alpha.1</tag>
     </scm>
 
     <developers>

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-core</artifactId>
@@ -384,7 +384,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-alpha.1</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-core</artifactId>
@@ -384,7 +384,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-core/pom.xml
+++ b/driver-core/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-core</artifactId>
@@ -384,7 +384,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2-SNAPSHOT</tag>
     </scm>
 
     <developers>

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-dist</artifactId>

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-dist</artifactId>

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-dist</artifactId>

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <artifactId>cassandra-driver-dist</artifactId>

--- a/driver-dist/pom.xml
+++ b/driver-dist/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-dist</artifactId>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <artifactId>cassandra-driver-parent</artifactId>
         <groupId>com.yugabyte</groupId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-examples</artifactId>
@@ -222,7 +222,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>HEAD</tag>
+        <tag>3.10.3-yb-2</tag>
     </scm>
 
     <developers>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <artifactId>cassandra-driver-parent</artifactId>
         <groupId>com.yugabyte</groupId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-examples</artifactId>
@@ -222,7 +222,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <artifactId>cassandra-driver-parent</artifactId>
         <groupId>com.yugabyte</groupId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <artifactId>cassandra-driver-examples</artifactId>
@@ -222,7 +222,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>HEAD</tag>
+        <tag>3.10.3-yb-2-alpha.1</tag>
     </scm>
 
     <developers>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <artifactId>cassandra-driver-parent</artifactId>
         <groupId>com.yugabyte</groupId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-examples</artifactId>
@@ -222,7 +222,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-alpha.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <artifactId>cassandra-driver-parent</artifactId>
         <groupId>com.yugabyte</groupId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-examples</artifactId>
@@ -222,7 +222,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>HEAD</tag>
+        <tag>3.10.3-yb-2-SNAPSHOT</tag>
     </scm>
 
     <developers>

--- a/driver-examples/pom.xml
+++ b/driver-examples/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <artifactId>cassandra-driver-parent</artifactId>
         <groupId>com.yugabyte</groupId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-examples</artifactId>
@@ -222,7 +222,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-SNAPSHOT</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/driver-extras/pom.xml
+++ b/driver-extras/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-extras</artifactId>
@@ -207,7 +207,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-extras/pom.xml
+++ b/driver-extras/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-extras</artifactId>
@@ -207,7 +207,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-SNAPSHOT</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-extras/pom.xml
+++ b/driver-extras/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-extras</artifactId>
@@ -207,7 +207,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-alpha.1</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-extras/pom.xml
+++ b/driver-extras/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-extras</artifactId>
@@ -207,7 +207,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2-SNAPSHOT</tag>
     </scm>
 
     <developers>

--- a/driver-extras/pom.xml
+++ b/driver-extras/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-extras</artifactId>
@@ -207,7 +207,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2</tag>
     </scm>
 
     <developers>

--- a/driver-extras/pom.xml
+++ b/driver-extras/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <artifactId>cassandra-driver-extras</artifactId>
@@ -207,7 +207,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2-alpha.1</tag>
     </scm>
 
     <developers>

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-mapping</artifactId>
@@ -184,7 +184,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-alpha.1</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-mapping</artifactId>
@@ -184,7 +184,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-SNAPSHOT</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-mapping</artifactId>
@@ -184,7 +184,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <artifactId>cassandra-driver-mapping</artifactId>
@@ -184,7 +184,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2-alpha.1</tag>
     </scm>
 
     <developers>

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-mapping</artifactId>
@@ -184,7 +184,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2</tag>
     </scm>
 
     <developers>

--- a/driver-mapping/pom.xml
+++ b/driver-mapping/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-mapping</artifactId>
@@ -184,7 +184,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2-SNAPSHOT</tag>
     </scm>
 
     <developers>

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-osgi</artifactId>
@@ -239,7 +239,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-SNAPSHOT</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-osgi</artifactId>
@@ -239,7 +239,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2-SNAPSHOT</tag>
     </scm>
 
     <developers>

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-osgi</artifactId>
@@ -239,7 +239,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-alpha.1</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-osgi</artifactId>
@@ -239,7 +239,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2-alpha.1</tag>
     </scm>
 
     <developers>

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-osgi</artifactId>
@@ -239,7 +239,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2</tag>
     </scm>
 
     <developers>

--- a/driver-tests/osgi/pom.xml
+++ b/driver-tests/osgi/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-osgi</artifactId>
@@ -239,7 +239,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-parent</artifactId>
@@ -67,7 +67,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2-alpha.1</tag>
     </scm>
 
     <developers>

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-parent</artifactId>
@@ -67,7 +67,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2</tag>
     </scm>
 
     <developers>

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-parent</artifactId>
@@ -67,7 +67,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-1</tag>
+        <tag>3.10.3-yb-2-SNAPSHOT</tag>
     </scm>
 
     <developers>

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-parent</artifactId>
@@ -67,7 +67,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-alpha.1</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-parent</artifactId>
@@ -67,7 +67,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-tests/pom.xml
+++ b/driver-tests/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-parent</artifactId>
@@ -67,7 +67,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-SNAPSHOT</tag>
+        <tag>3.8.0-yb-1</tag>
     </scm>
 
     <developers>

--- a/driver-tests/shading/pom.xml
+++ b/driver-tests/shading/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/driver-tests/shading/pom.xml
+++ b/driver-tests/shading/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/driver-tests/shading/pom.xml
+++ b/driver-tests/shading/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/driver-tests/shading/pom.xml
+++ b/driver-tests/shading/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/driver-tests/shading/pom.xml
+++ b/driver-tests/shading/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/driver-tests/shading/shaded/pom.xml
+++ b/driver-tests/shading/shaded/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-shading-shaded</artifactId>

--- a/driver-tests/shading/shaded/pom.xml
+++ b/driver-tests/shading/shaded/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-shading-shaded</artifactId>

--- a/driver-tests/shading/shaded/pom.xml
+++ b/driver-tests/shading/shaded/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-shading-shaded</artifactId>

--- a/driver-tests/shading/shaded/pom.xml
+++ b/driver-tests/shading/shaded/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-shading-shaded</artifactId>

--- a/driver-tests/shading/shaded/pom.xml
+++ b/driver-tests/shading/shaded/pom.xml
@@ -35,7 +35,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-shading-shaded</artifactId>

--- a/driver-tests/shading/unshaded/pom.xml
+++ b/driver-tests/shading/unshaded/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-shading-unshaded</artifactId>

--- a/driver-tests/shading/unshaded/pom.xml
+++ b/driver-tests/shading/unshaded/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-shading-unshaded</artifactId>

--- a/driver-tests/shading/unshaded/pom.xml
+++ b/driver-tests/shading/unshaded/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-shading-unshaded</artifactId>

--- a/driver-tests/shading/unshaded/pom.xml
+++ b/driver-tests/shading/unshaded/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-shading-unshaded</artifactId>

--- a/driver-tests/shading/unshaded/pom.xml
+++ b/driver-tests/shading/unshaded/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-shading</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-shading-unshaded</artifactId>

--- a/driver-tests/stress/pom.xml
+++ b/driver-tests/stress/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-stress</artifactId>
@@ -119,7 +119,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>HEAD</tag>
+        <tag>3.10.3-yb-2-SNAPSHOT</tag>
     </scm>
 
     <developers>

--- a/driver-tests/stress/pom.xml
+++ b/driver-tests/stress/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-3-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-stress</artifactId>
@@ -119,7 +119,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/driver-tests/stress/pom.xml
+++ b/driver-tests/stress/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-stress</artifactId>
@@ -119,7 +119,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>HEAD</tag>
+        <tag>3.10.3-yb-2</tag>
     </scm>
 
     <developers>

--- a/driver-tests/stress/pom.xml
+++ b/driver-tests/stress/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-stress</artifactId>
@@ -119,7 +119,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-SNAPSHOT</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/driver-tests/stress/pom.xml
+++ b/driver-tests/stress/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-SNAPSHOT</version>
+        <version>3.10.3-yb-2-alpha.1</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-stress</artifactId>
@@ -119,7 +119,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>HEAD</tag>
+        <tag>3.10.3-yb-2-alpha.1</tag>
     </scm>
 
     <developers>

--- a/driver-tests/stress/pom.xml
+++ b/driver-tests/stress/pom.xml
@@ -36,7 +36,7 @@
     <parent>
         <groupId>com.yugabyte</groupId>
         <artifactId>cassandra-driver-tests-parent</artifactId>
-        <version>3.10.3-yb-2-alpha.1</version>
+        <version>3.10.3-yb-2-SNAPSHOT</version>
     </parent>
 
     <artifactId>cassandra-driver-tests-stress</artifactId>
@@ -119,7 +119,7 @@
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-alpha.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.yugabyte</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>3.10.3-yb-2-SNAPSHOT</version>
+    <version>3.10.3-yb-2-alpha.1</version>
     <packaging>pom</packaging>
     <name>Java Driver for YugaByte DB</name>
     <description>
@@ -1158,7 +1158,7 @@ limitations under the License.
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-x</tag>
+        <tag>3.10.3-yb-2-alpha.1</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.yugabyte</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>3.10.3-yb-2-SNAPSHOT</version>
+    <version>3.10.3-yb-2-alpha.1</version>
     <packaging>pom</packaging>
     <name>Java Driver for YugaByte DB</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.yugabyte</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>3.10.3-yb-2-alpha.1</version>
+    <version>3.10.3-yb-2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Java Driver for YugaByte DB</name>
     <description>
@@ -1158,7 +1158,7 @@ limitations under the License.
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-alpha.1</tag>
+        <tag>3.8.0-yb-x</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.yugabyte</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>3.10.3-yb-2-SNAPSHOT</version>
+    <version>3.10.3-yb-2</version>
     <packaging>pom</packaging>
     <name>Java Driver for YugaByte DB</name>
     <description>
@@ -1158,7 +1158,7 @@ limitations under the License.
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-x</tag>
+        <tag>3.10.3-yb-2</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.yugabyte</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>3.10.3-yb-2-alpha.1</version>
+    <version>3.10.3-yb-2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Java Driver for YugaByte DB</name>
     <description>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.yugabyte</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>3.10.3-yb-2</version>
+    <version>3.10.3-yb-3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Java Driver for YugaByte DB</name>
     <description>
@@ -1158,7 +1158,7 @@ limitations under the License.
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2</tag>
+        <tag>3.8.0-yb-x</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -69,9 +69,9 @@
         <snappy.version>1.1.2.6</snappy.version>
         <lz4.version>1.4.1</lz4.version>
         <hdr.version>2.1.10</hdr.version>
-        <jackson.version>2.8.11</jackson.version>
+        <jackson.version>2.9.10</jackson.version>
         <!-- jackson-databind 2.7.x is the last to support java 6 -->
-        <jackson-databind.version>2.7.9.3</jackson-databind.version>
+        <jackson-databind.version>2.9.10.8</jackson-databind.version>
         <joda.version>2.9.9</joda.version>
         <jsr353-api.version>1.0</jsr353-api.version>
         <jsr353-ri.version>1.0.4</jsr353-ri.version>
@@ -525,8 +525,8 @@
                             <link>https://google.github.io/guava/releases/19.0/api/docs/</link>
                             <link>http://netty.io/4.0/api/</link>
                             <link>http://www.joda.org/joda-time/apidocs/</link>
-                            <link>http://fasterxml.github.io/jackson-core/javadoc/2.8/</link>
-                            <link>http://fasterxml.github.io/jackson-databind/javadoc/2.7/</link>
+                            <link>http://fasterxml.github.io/jackson-core/javadoc/2.9/</link>
+                            <link>http://fasterxml.github.io/jackson-databind/javadoc/2.9/</link>
                             <link>https://javaee-spec.java.net/nonav/javadocs/</link>
                         </links>
                         <!-- optional dependencies from other modules (must be explicitly declared here in order to be correctly resolved) -->

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.yugabyte</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>3.10.3-yb-2</version>
+    <version>3.10.3-yb-2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Java Driver for YugaByte DB</name>
     <description>
@@ -1158,7 +1158,7 @@ limitations under the License.
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.10.3-yb-2-SNAPSHOT</tag>
+        <tag>3.8.0-yb-x</tag>
     </scm>
 
     <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.yugabyte</groupId>
     <artifactId>cassandra-driver-parent</artifactId>
-    <version>3.10.3-yb-2-SNAPSHOT</version>
+    <version>3.10.3-yb-2</version>
     <packaging>pom</packaging>
     <name>Java Driver for YugaByte DB</name>
     <description>
@@ -1158,7 +1158,7 @@ limitations under the License.
         <connection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</connection>
         <developerConnection>scm:git:git@github.com:YugaByte/cassandra-java-driver.git</developerConnection>
         <url>https://github.com/yugabyte/cassandra-java-driver</url>
-        <tag>3.8.0-yb-x</tag>
+        <tag>3.10.3-yb-2-SNAPSHOT</tag>
     </scm>
 
     <developers>


### PR DESCRIPTION
There were quite a few vulnerabilities reported due to the use of Jackson binding version 2.7.9.3.
The highest suggested upgrade was to 2.9.10.8

mvn package runs clean.

This is already released as driver version 3.10.3-yb-2-alpha.1. Being verified via phabricator diff id D13225.
Plan to retag this as 3.10.3-yb-2. [EDIT: tagged as 3.10.3-yb-2]