### PR TITLE
[DB-2661] Allow primary key column with VARINT in partitionaware policy

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/session/Session.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/session/Session.java
@@ -142,8 +142,8 @@ public interface Session extends AsyncAutoCloseable {
   }
 
   /**
-   * Convenience method to call {@link #refreshSchemaAsync()} and block for the result.
-   * This method is bounded by the specified timeout.
+   * Convenience method to call {@link #refreshSchemaAsync()} and block for the result. This method
+   * is bounded by the specified timeout.
    *
    * <p>This must not be called on a driver thread.
    */

--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
@@ -346,6 +346,7 @@ public class PartitionAwarePolicy extends YugabyteDefaultLoadBalancingPolicy
          * for Decimal types.
          */
       case ProtocolConstants.DataType.DECIMAL:
+      case ProtocolConstants.DataType.VARINT:
       case ProtocolConstants.DataType.TIME:
         channel.write(value);
         break;
@@ -443,7 +444,6 @@ public class PartitionAwarePolicy extends YugabyteDefaultLoadBalancingPolicy
       case ProtocolConstants.DataType.COUNTER:
       case ProtocolConstants.DataType.CUSTOM:
       case ProtocolConstants.DataType.TUPLE:
-      case ProtocolConstants.DataType.VARINT:
         throw new UnsupportedOperationException(
             "Datatype with Hex Code: " + typeCode + " not supported in a partition key column");
     }


### PR DESCRIPTION
Customer is seeing below errors when they use VARINT as datatype for one of the column in the partition key. Exception is thrown:

```
java.lang.UnsupportedOperationException: Datatype with Hex Code: 14 not supported in a partition key column at com.yugabyte.oss.driver.internal.core.loadbalancing.PartitionAwarePolicy.AppendValueToChannel(PartitionAwarePolicy.java:447)
```
when using YB Driver 4.6.0-yb-10.

Code changes to allow `VARINT` to be used as PARTITIONKEY, however the VARINT types will not provide intelligent routing. Code fix similar to [#6966](https://github.com/yugabyte/cassandra-java-driver/commit/b95006d94a29b2ab1dc2e39889e2ddf93e6f34c7).
