### PR TITLE
Backport Prevent control connection from scheduling too many reconnections

### DIFF
--- a/changelog/README.md
+++ b/changelog/README.md
@@ -2,6 +2,8 @@
 
 <!-- Note: contrary to 3.x, insert new entries *first* in their section -->
 
+ - [bug] JAVA-2911: Prevent control connection from scheduling too many reconnections
+
  - [improvement] JAVA-2905: Prevent new connections from using a protocol version higher than the negotiated one
  - [new feature] JAVA-2793: Add composite config loader
 

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/control/ControlConnection.java
@@ -430,13 +430,15 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
                       connect(nodes, errors, onSuccess, onFailure);
                     } else {
                       LOG.debug("[{}] New channel opened {}", logPrefix, channel);
-                      // Make sure previous channel gets closed (it may still be open if
-                      // reconnection was forced)
                       DriverChannel previousChannel = ControlConnection.this.channel;
+                      ControlConnection.this.channel = channel;
                       if (previousChannel != null) {
+                        // We were reconnecting: make sure previous channel gets closed (it may
+                        // still be open if reconnection was forced)
+                        LOG.debug(
+                            "[{}] Forcefully closing previous channel {}", logPrefix, channel);
                         previousChannel.forceClose();
                       }
-                      ControlConnection.this.channel = channel;
                       context.getEventBus().fire(ChannelEvent.channelOpened(node));
                       channel
                           .closeFuture()
@@ -508,9 +510,21 @@ public class ControlConnection implements EventCallback, AsyncAutoCloseable {
     private void onChannelClosed(DriverChannel channel, Node node) {
       assert adminExecutor.inEventLoop();
       if (!closeWasCalled) {
-        LOG.debug("[{}] Lost channel {}", logPrefix, channel);
         context.getEventBus().fire(ChannelEvent.channelClosed(node));
-        reconnection.start();
+        // If this channel is the current control channel, we must start a
+        // reconnection attempt to get a new control channel.
+        if (channel == ControlConnection.this.channel) {
+          LOG.debug(
+              "[{}] The current control channel {} was closed, scheduling reconnection",
+              logPrefix,
+              channel);
+          reconnection.start();
+        } else {
+          LOG.trace(
+              "[{}] A previous control channel {} was closed, reconnection not required",
+              logPrefix,
+              channel);
+        }
       }
     }
 


### PR DESCRIPTION
Upstream commit was 22d8bc5f5d81adad760377b85f6617cf6fb723fd

JAVA-2911: Prevent control connection from scheduling too many reconnections