### PR TITLE
JAVA-3022: Implementation of address translator for fixed hostname (#1597)

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslator.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslator.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import com.datastax.oss.driver.api.core.addresstranslation.AddressTranslator;
+import com.datastax.oss.driver.api.core.config.DriverOption;
+import com.datastax.oss.driver.api.core.context.DriverContext;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.net.InetSocketAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This translator always returns same hostname, no matter what IP address a node has but still
+ * using its native transport port.
+ *
+ * <p>The translator can be used for scenarios when all nodes are behind some kind of proxy, and it
+ * is not tailored for one concrete use case. One can use this, for example, for AWS PrivateLink as
+ * all nodes would be exposed to consumer - behind one hostname pointing to AWS Endpoint.
+ */
+public class FixedHostNameAddressTranslator implements AddressTranslator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(FixedHostNameAddressTranslator.class);
+
+  public static final String ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME =
+      "advanced.address-translator.advertised-hostname";
+
+  public static DriverOption ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME_OPTION =
+      new DriverOption() {
+        @NonNull
+        @Override
+        public String getPath() {
+          return ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME;
+        }
+      };
+
+  private final String advertisedHostname;
+  private final String logPrefix;
+
+  public FixedHostNameAddressTranslator(@NonNull DriverContext context) {
+    logPrefix = context.getSessionName();
+    advertisedHostname =
+        context
+            .getConfig()
+            .getDefaultProfile()
+            .getString(ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME_OPTION);
+  }
+
+  @NonNull
+  @Override
+  public InetSocketAddress translate(@NonNull InetSocketAddress address) {
+    final int port = address.getPort();
+    LOG.debug("[{}] Resolved {}:{} to {}:{}", logPrefix, address, port, advertisedHostname, port);
+    return new InetSocketAddress(advertisedHostname, port);
+  }
+
+  @Override
+  public void close() {}
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -874,10 +874,13 @@ datastax-java-driver {
     #
     # The driver provides the following implementations out of the box:
     # - PassThroughAddressTranslator: returns all addresses unchanged
+    # - FixedHostNameAddressTranslator: translates all addresses to a specific hostname.
     #
     # You can also specify a custom class that implements AddressTranslator and has a public
     # constructor with a DriverContext argument.
     class = PassThroughAddressTranslator
+    # This property has to be set only in case you use FixedHostNameAddressTranslator.
+    # advertised-hostname = mycustomhostname
   }
 
   # Whether to resolve the addresses passed to `basic.contact-points`.

--- a/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslatorTest.java
+++ b/core/src/test/java/com/datastax/oss/driver/internal/core/addresstranslation/FixedHostNameAddressTranslatorTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright DataStax, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.addresstranslation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.config.DriverExecutionProfile;
+import com.datastax.oss.driver.internal.core.context.DefaultDriverContext;
+import com.datastax.oss.driver.internal.core.context.MockedDriverContextFactory;
+import java.net.InetSocketAddress;
+import java.util.Optional;
+import org.junit.Test;
+
+public class FixedHostNameAddressTranslatorTest {
+
+  @Test
+  public void should_translate_address() {
+    DriverExecutionProfile defaultProfile = mock(DriverExecutionProfile.class);
+    when(defaultProfile.getString(
+            FixedHostNameAddressTranslator.ADDRESS_TRANSLATOR_ADVERTISED_HOSTNAME_OPTION))
+        .thenReturn("myaddress");
+    DefaultDriverContext defaultDriverContext =
+        MockedDriverContextFactory.defaultDriverContext(Optional.of(defaultProfile));
+
+    FixedHostNameAddressTranslator translator =
+        new FixedHostNameAddressTranslator(defaultDriverContext);
+    InetSocketAddress address = new InetSocketAddress("192.0.2.5", 6061);
+
+    assertThat(translator.translate(address)).isEqualTo(new InetSocketAddress("myaddress", 6061));
+  }
+}


### PR DESCRIPTION
This adds `FixedHostNameAddressTranslator` class.

For AWS PrivateLink as all nodes would be exposed to consumer - behind one hostname pointing to AWS Endpoint.

The original commit was 65d2c19c401175dcc6c370560dd5f783d05b05b9
The test is covered by FixedHostNameAddressTranslatorTest

The backport is done proactively.