### PR TITLE
[FP-3140] Add start time to AsyncResultSet

### DIFF
--- a/core/src/main/java/com/datastax/oss/driver/api/core/cql/AsyncResultSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/cql/AsyncResultSet.java
@@ -40,4 +40,14 @@ public interface AsyncResultSet extends AsyncPagingIterable<Row, AsyncResultSet>
    */
   @Override
   boolean wasApplied();
+
+  /*
+   * This method returns the time at which request processing started.
+   */
+  long getStartTime();
+
+  /*
+   * This method sets the time at which request processing started.
+   */
+  void setStartTime(long start);
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/CqlRequestHandler.java
@@ -329,6 +329,7 @@ public class CqlRequestHandler implements Throttled {
           buildExecutionInfo(callback, resultMessage, responseFrame, schemaInAgreement);
       AsyncResultSet resultSet =
           Conversions.toResultSet(resultMessage, executionInfo, session, context);
+      resultSet.setStartTime(startTimeNanos);
       if (result.complete(resultSet)) {
         cancelScheduledTasks();
         throttler.signalSuccess(this);

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultAsyncResultSet.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/cql/DefaultAsyncResultSet.java
@@ -44,6 +44,7 @@ public class DefaultAsyncResultSet implements AsyncResultSet {
   private final CqlSession session;
   private final CountingIterator<Row> iterator;
   private final Iterable<Row> currentPage;
+  private long startTime;
 
   public DefaultAsyncResultSet(
       ColumnDefinitions definitions,
@@ -69,6 +70,16 @@ public class DefaultAsyncResultSet implements AsyncResultSet {
   @Override
   public ColumnDefinitions getColumnDefinitions() {
     return definitions;
+  }
+
+  @Override
+  public long getStartTime() {
+    return startTime;
+  }
+
+  @Override
+  public void setStartTime(long start) {
+    this.startTime = start;
   }
 
   @NonNull
@@ -126,6 +137,14 @@ public class DefaultAsyncResultSet implements AsyncResultSet {
 
   static AsyncResultSet empty(final ExecutionInfo executionInfo) {
     return new AsyncResultSet() {
+      @Override
+      public void setStartTime(long start) {}
+
+      @Override
+      public long getStartTime() {
+        return 0;
+      }
+
       @NonNull
       @Override
       public ColumnDefinitions getColumnDefinitions() {

--- a/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/MockAsyncResultSet.java
+++ b/core/src/test/java/com/datastax/dse/driver/internal/core/cql/reactive/MockAsyncResultSet.java
@@ -50,6 +50,14 @@ public class MockAsyncResultSet implements AsyncResultSet {
   }
 
   @Override
+  public void setStartTime(long start) {}
+
+  @Override
+  public long getStartTime() {
+    return 0;
+  }
+
+  @Override
   public Row one() {
     Row next = iterator.next();
     remaining--;


### PR DESCRIPTION
This PR adds the start time to `AsyncResultSet` so that the caller can use the information for metrics reporting.

The start time is retrieved from `CqlRequestHandler`.