### PR TITLE
Fix for the Prepared IN Clause giving java.lang.ClassCastException error

### DIFF
--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
@@ -25,10 +25,7 @@ import com.datastax.oss.driver.api.core.metadata.NodeState;
 import com.datastax.oss.driver.api.core.session.Request;
 import com.datastax.oss.driver.api.core.session.Session;
 import com.datastax.oss.driver.api.core.tracker.RequestTracker;
-import com.datastax.oss.driver.api.core.type.DataType;
-import com.datastax.oss.driver.api.core.type.MapType;
-import com.datastax.oss.driver.api.core.type.SetType;
-import com.datastax.oss.driver.api.core.type.UserDefinedType;
+import com.datastax.oss.driver.api.core.type.*;
 import com.datastax.oss.driver.internal.core.util.collection.QueryPlan;
 import com.datastax.oss.protocol.internal.ProtocolConstants;
 import com.yugabyte.oss.driver.api.core.DefaultPartitionMetadata;
@@ -386,7 +383,20 @@ public class PartitionAwarePolicy extends YugabyteDefaultLoadBalancingPolicy
           channel.write(value);
           break;
         }
-      case ProtocolConstants.DataType.LIST:
+      case ProtocolConstants.DataType.LIST: {
+        ListType listType = (ListType) type;
+        DataType dataTypeOfListValue = listType.getElementType();
+        int length = value.getInt();
+        for (int j = 0; j < length; j++) {
+          // Appending each element.
+          int size = value.getInt();
+          ByteBuffer buf = value.slice();
+          buf.limit(size);
+          AppendValueToChannel(dataTypeOfListValue, buf, channel);
+          value.position(value.position() + size);
+        }
+        break;
+      }
       case ProtocolConstants.DataType.SET:
         {
           SetType setType = (SetType) type;


### PR DESCRIPTION
Problem:

Getting the “error java.lang.ClassCastException: java.util.ArrayList cannot be cast to com.datastax.oss.driver.api.core.type.SetType” when IN Clause contains list as the bound variable. More details here. 

Reason:

The issue was because the list types and set types were handled similarly in the 4.x driver where the Datatype was explicitly converted to Set type. In the 4.x driver,  DataType is an interface, which different datatypes implement. 
The issue did not come on the 3.x driver because there was no explicit type conversion, since datatype is not an interface in the 3.x driver but a class that handles all the data types.

Solution:

Added a different implementation for list type