### PR TITLE
Support a case when the cluster could be behind a load-balancer

### DIFF
--- a/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
+++ b/core/src/main/java/com/yugabyte/oss/driver/internal/core/loadbalancing/PartitionAwarePolicy.java
@@ -383,20 +383,21 @@ public class PartitionAwarePolicy extends YugabyteDefaultLoadBalancingPolicy
           channel.write(value);
           break;
         }
-      case ProtocolConstants.DataType.LIST: {
-        ListType listType = (ListType) type;
-        DataType dataTypeOfListValue = listType.getElementType();
-        int length = value.getInt();
-        for (int j = 0; j < length; j++) {
-          // Appending each element.
-          int size = value.getInt();
-          ByteBuffer buf = value.slice();
-          buf.limit(size);
-          AppendValueToChannel(dataTypeOfListValue, buf, channel);
-          value.position(value.position() + size);
+      case ProtocolConstants.DataType.LIST:
+        {
+          ListType listType = (ListType) type;
+          DataType dataTypeOfListValue = listType.getElementType();
+          int length = value.getInt();
+          for (int j = 0; j < length; j++) {
+            // Appending each element.
+            int size = value.getInt();
+            ByteBuffer buf = value.slice();
+            buf.limit(size);
+            AppendValueToChannel(dataTypeOfListValue, buf, channel);
+            value.position(value.position() + size);
+          }
+          break;
         }
-        break;
-      }
       case ProtocolConstants.DataType.SET:
         {
           SetType setType = (SetType) type;


### PR DESCRIPTION
The driver expects direct access to all the nodes in a YugabyteDB cluster.
We have seen some users use the cluster through an external load-balancer.
While it is not a recommended practice, the driver still functions but with less efficiency and a hampered retry policy.

This change aims to address a case which cannot be handled through a custom `RetryPolicy`.
If a request fails during a `send` to a node, AND the query-plan for the request does not have any other nodes AND if the node still has some connections, then retry `send` one more time.
This should not cause any perf impact since it is retry-once in a rare case, in a non-LB setup.

Changes in `PartitionAwarePolicy` are purely formatting related.

**Testing**
This was tested manually through an app connecting to a YB Managed cluster.
No unit test possible since it involves external load-balancer.