### PR TITLE
Added support for non-native UINT32 type for YB

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -71,7 +71,7 @@
       <dependency>
         <groupId>com.yugabyte</groupId>
         <artifactId>native-protocol</artifactId>
-        <version>1.5.1-yb-2</version>
+        <version>1.5.1-yb-3</version>
       </dependency>
       <dependency>
         <groupId>com.datastax.oss</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -41,6 +41,7 @@
     <dependency>
       <groupId>com.yugabyte</groupId>
       <artifactId>native-protocol</artifactId>
+      <version>1.5.1-yb-3</version>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/DataTypes.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/DataTypes.java
@@ -51,6 +51,7 @@ public class DataTypes {
   public static final DataType TINYINT = new PrimitiveType(ProtocolConstants.DataType.TINYINT);
   public static final DataType DURATION = new PrimitiveType(ProtocolConstants.DataType.DURATION);
   public static final DataType JSONB = new PrimitiveType(ProtocolConstants.DataType.JSONB);
+  public static final DataType UINT32 = new PrimitiveType(ProtocolConstants.DataType.UINT32);
 
   @NonNull
   public static DataType custom(@NonNull String className) {

--- a/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.java
+++ b/core/src/main/java/com/datastax/oss/driver/api/core/type/codec/TypeCodecs.java
@@ -45,6 +45,7 @@ import com.datastax.oss.driver.internal.core.type.codec.TimeUuidCodec;
 import com.datastax.oss.driver.internal.core.type.codec.TimestampCodec;
 import com.datastax.oss.driver.internal.core.type.codec.TinyIntCodec;
 import com.datastax.oss.driver.internal.core.type.codec.TupleCodec;
+import com.datastax.oss.driver.internal.core.type.codec.UInt32Codec;
 import com.datastax.oss.driver.internal.core.type.codec.UdtCodec;
 import com.datastax.oss.driver.internal.core.type.codec.UuidCodec;
 import com.datastax.oss.driver.internal.core.type.codec.VarIntCodec;
@@ -90,6 +91,9 @@ public class TypeCodecs {
 
   /** The default codec that maps CQL type {@code int} to Java's {@code int}. */
   public static final PrimitiveIntCodec INT = new IntCodec();
+
+  /** The default codec that maps CQL type {@code uint32} to Java's {@code long}. */
+  public static final PrimitiveLongCodec UINT32 = new UInt32Codec();
 
   /** The default codec that maps CQL type {@code bigint} to Java's {@code long}. */
   public static final PrimitiveLongCodec BIGINT = new BigIntCodec();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DataTypeCqlNameParser.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/metadata/schema/parsing/DataTypeCqlNameParser.java
@@ -324,5 +324,6 @@ public class DataTypeCqlNameParser implements DataTypeParser {
           .put("smallint", DataTypes.SMALLINT)
           .put("duration", DataTypes.DURATION)
           .put("jsonb", DataTypes.JSONB)
+          .put("uint32", DataTypes.UINT32)
           .build();
 }

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/DataTypeHelper.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/DataTypeHelper.java
@@ -99,7 +99,8 @@ public class DataTypeHelper {
           DataTypes.SMALLINT,
           DataTypes.TINYINT,
           DataTypes.DURATION,
-          DataTypes.JSONB);
+          DataTypes.JSONB,
+          DataTypes.UINT32);
 
   private static IntMap<DataType> sortByProtocolCode(DataType... types) {
     IntMap.Builder<DataType> builder = IntMap.builder();

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/PrimitiveType.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/PrimitiveType.java
@@ -97,6 +97,8 @@ public class PrimitiveType implements DataType, Serializable {
         return "FLOAT";
       case ProtocolConstants.DataType.INT:
         return "INT";
+      case ProtocolConstants.DataType.UINT32:
+        return "UINT32";
       case ProtocolConstants.DataType.TIMESTAMP:
         return "TIMESTAMP";
       case ProtocolConstants.DataType.UUID:

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/UInt32Codec.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/UInt32Codec.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright YugabyteDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.datastax.oss.driver.internal.core.type.codec;
+
+import com.datastax.oss.driver.api.core.ProtocolVersion;
+import com.datastax.oss.driver.api.core.type.DataType;
+import com.datastax.oss.driver.api.core.type.DataTypes;
+import com.datastax.oss.driver.api.core.type.codec.PrimitiveLongCodec;
+import com.datastax.oss.driver.api.core.type.reflect.GenericType;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.nio.ByteBuffer;
+import net.jcip.annotations.ThreadSafe;
+
+@ThreadSafe
+public class UInt32Codec implements PrimitiveLongCodec {
+
+  @NonNull
+  @Override
+  public GenericType<Long> getJavaType() {
+    return GenericType.LONG;
+  }
+
+  @NonNull
+  @Override
+  public DataType getCqlType() {
+    return DataTypes.UINT32;
+  }
+
+  @Override
+  public boolean accepts(@NonNull Object value) {
+    // UInt32Codec should only match when CQL type is explicitly UINT32.
+    // For value-only lookups, we return false so that BigIntCodec (the default for Long)
+    // is selected instead. This prevents UInt32Codec from matching Long values
+    // when no CQL type is provided, since inferCqlTypeFromValue() returns BIGINT for Long.
+    // When codecFor(DataTypes.UINT32, value) is called, the codec is selected by protocol code
+    // first, and if accepts() returns false, it falls through to getCachedCodec() which
+    // will still work correctly.
+    return false;
+  }
+
+  @Override
+  public boolean accepts(@NonNull Class<?> javaClass) {
+    return javaClass == Long.class || javaClass == long.class;
+  }
+
+  @Nullable
+  @Override
+  public ByteBuffer encodePrimitive(long value, @NonNull ProtocolVersion protocolVersion) {
+    if (value < 0 || value > 0xFFFFFFFFL) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Invalid unsigned 32-bits integer value: %d (must be between 0 and %d)",
+              value, 0xFFFFFFFFL));
+    }
+    ByteBuffer bytes = ByteBuffer.allocate(4);
+    // Write as unsigned 32-bit integer
+    bytes.putInt(0, (int) value);
+    return bytes;
+  }
+
+  @Override
+  public long decodePrimitive(
+      @Nullable ByteBuffer bytes, @NonNull ProtocolVersion protocolVersion) {
+    if (bytes == null || bytes.remaining() == 0) {
+      return 0;
+    } else if (bytes.remaining() != 4) {
+      throw new IllegalArgumentException(
+          "Invalid unsigned 32-bits integer value, expecting 4 bytes but got " + bytes.remaining());
+    } else {
+      // Read as unsigned 32-bit integer
+      int signed = bytes.getInt(bytes.position());
+      // Convert signed int to unsigned long
+      return signed & 0xFFFFFFFFL;
+    }
+  }
+
+  @NonNull
+  @Override
+  public String format(@Nullable Long value) {
+    return (value == null) ? "NULL" : Long.toUnsignedString(value);
+  }
+
+  @Nullable
+  @Override
+  public Long parse(@Nullable String value) {
+    try {
+      return (value == null || value.isEmpty() || value.equalsIgnoreCase("NULL"))
+          ? null
+          : Long.parseUnsignedLong(value);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format("Cannot parse unsigned 32-bits integer value from \"%s\"", value), e);
+    }
+  }
+}

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistry.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CachingCodecRegistry.java
@@ -242,9 +242,15 @@ public abstract class CachingCodecRegistry implements MutableCodecRegistry {
     LOG.trace("[{}] Looking up codec for CQL type {} and object {}", logPrefix, cqlType, value);
 
     TypeCodec<?> primitiveCodec = primitiveCodecsByCode.get(cqlType.getProtocolCode());
-    if (primitiveCodec != null && primitiveCodec.accepts(value)) {
-      LOG.trace("[{}] Found matching primitive codec {}", logPrefix, primitiveCodec);
-      return uncheckedCast(primitiveCodec);
+    if (primitiveCodec != null) {
+      // For primitive codecs, check accepts(value) first, but if it returns false,
+      // still use the codec if the value's Java type matches the codec's Java type.
+      // This allows codecs like UInt32Codec to reject value-only lookups while
+      // still working when the CQL type is explicitly provided.
+      if (primitiveCodec.accepts(value) || primitiveCodec.accepts(value.getClass())) {
+        LOG.trace("[{}] Found matching primitive codec {}", logPrefix, primitiveCodec);
+        return uncheckedCast(primitiveCodec);
+      }
     }
     for (TypeCodec<?> userCodec : userCodecs) {
       if (userCodec.accepts(cqlType) && userCodec.accepts(value)) {

--- a/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CodecRegistryConstants.java
+++ b/core/src/main/java/com/datastax/oss/driver/internal/core/type/codec/registry/CodecRegistryConstants.java
@@ -39,6 +39,7 @@ public class CodecRegistryConstants {
         TypeCodecs.TIMEUUID,
         TypeCodecs.TIMESTAMP,
         TypeCodecs.INT,
+        TypeCodecs.UINT32,
         TypeCodecs.BIGINT,
         TypeCodecs.BLOB,
         TypeCodecs.DOUBLE,


### PR DESCRIPTION
Added support for non-native YCQL type UINT32 to cover schema parsing of internal system tables, such that tools like `dsbulk` can function without throwing errors during the schema parse phase. 